### PR TITLE
Use relative_url filter for portfolio stylesheet

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: "Software Quality Assurance"
 permalink: /
 ---
 
-<link rel="stylesheet" href="/assets/css/portfolio.css">
+<link rel="stylesheet" href="{{ '/assets/css/portfolio.css' | relative_url }}">
 
 <nav>
   <a href="#home">Home</a> |


### PR DESCRIPTION
## Summary
- use Jekyll's `relative_url` filter for the portfolio stylesheet in `index.md`

## Testing
- `bundle exec jekyll build`
- `bundle exec jekyll serve --detach`
- `curl -I http://127.0.0.1:4000/assets/css/portfolio.css`


------
https://chatgpt.com/codex/tasks/task_e_68963743700083318b8f04614011549e