### PR TITLE
Add copyright include

### DIFF
--- a/_includes/copyright.html
+++ b/_includes/copyright.html
@@ -1,0 +1,1 @@
+<div class="copyright">&copy; {{ site.time | date: "%Y" }} {{ site.title }}</div>


### PR DESCRIPTION
## Summary
- add simple copyright include used by default layout

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68963633c7a083318d880cb0104effb4